### PR TITLE
Set shortlinks to update every 30 minutes instead of nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,21 +8,22 @@ workflows:
 
   # Need to define two workflows
   # See: https://ideas.circleci.com/ideas/CCI-I-627
-  on_commit:
+  on-commit:
     jobs:
-      - update_shortlinks:
+      - update-shortlinks:
           filters:
             branches:
               only: master
 
   # scheduled workflow
-  nightly:
+  every-15-min:
     jobs:
-      - update_shortlinks
+      - update-shortlinks
     triggers:
       - schedule:
-          # Every night at 4am ET
-          cron: "0 9 * * *"
+          # Every 30 minutes
+          # See: https://circleci.com/docs/2.0/workflows/#specifying-a-valid-schedule
+          cron: "0,30 * * * *"
           filters:
             branches:
               only: master
@@ -81,7 +82,7 @@ jobs:
               --github-repo "$CIRCLE_PROJECT_USERNAME/december-retreat" \
               --resource-list "examples/files-to-backup.csv"
 
-  update_shortlinks:
+  update-shortlinks:
     <<: *default_job
     steps:
       - checkout

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The schedule is set in the [`.circleci/config.yml`][config] file within this rep
 
 ## Tasks/Jobs
 
-As configured, jobs will run both **nightly**, and **on each commit** to `master`. (Be sure that all jobs are ok to run repeatedly.)
+As configured, jobs will run both **every 30 minutes**, and **on each commit** to `master`. (Be sure that all jobs are ok to run repeatedly.)
 
 ### `update_shortlinks`
 
@@ -42,7 +42,7 @@ Uses [`hyphacoop/spreadsheet2shortlinks`][shortlinks-cli] commandline tool.
    [shortlinks]: https://link.hypha.coop/shortlinks
    [shortlinks-cli]: https://github.com/hyphacoop/spreadsheet2shortlinks
 
-:clock1030: Runs nightly at 4am ET.  
+:clock1030: Runs every 30 minutes.  
 :scroll: [Run logs][logs] accessible on Circle CI.  
 :hammer_and_wrench: Configured in [`.circleci/config.yml`][config]
 


### PR DESCRIPTION
Re-ticketed from hyphacoop/handbook#59

Future consideration: if we moved this script right into `hyphacoop/shortlinks` and leaned on GitHub Actions, it could run in direct reaction to changes in the specific file, but seems overboard rn (would help us be more green with CPU cycles 😉 )